### PR TITLE
Fix sidebar_list for when the sidebar contains an unresolvable urlRef

### DIFF
--- a/src/main.m
+++ b/src/main.m
@@ -133,11 +133,14 @@ void sidebar_list()
         // LSSharedFileListItemResolve(sflItemRef, kLSSharedFileListNoUserInteraction | kLSSharedFileListDoNotMountVolumes, &urlRef, NULL);
         urlRef = LSSharedFileListItemCopyResolvedURL(sflItemRef, kLSSharedFileListNoUserInteraction | kLSSharedFileListDoNotMountVolumes, NULL);
         
-        if (urlRef == NULL) break;
-        
-        printf("%s -> %s\n",
+        if (urlRef == NULL) {
+            printf("%s -> NOTFOUND\n",
+                   [(NSString *) CFBridgingRelease(nameRef) UTF8String]);
+        } else {
+            printf("%s -> %s\n",
                [(NSString *) CFBridgingRelease(nameRef) UTF8String],
                [(NSString *) CFBridgingRelease(CFURLGetString(urlRef)) UTF8String]);
+        }
     }
     
     CFRelease(sflRef);


### PR DESCRIPTION
Currently, 'mysides list' stops listing if it gets to an entry with an unresolvable file URL.

These are entries that show "Original item cannot be found" when you click on them in the sidebar.
Unresolvable file URL entries are less common prior to MacOS 10.11 and are in any case quite hard to reproduce.

This change fixes this issue with 'mysides list'.
