### PR TITLE
Add simple installation docs and homebrew reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ A simple CLI tool for Finder sidebar modification.
 
     $ sfltool add-item com.apple.LSSharedFileList.FavoriteItems file:///Path/To/Sidebar/Folder
 
+## Installing ##
+
+The easiest option is to install via Homebrew Casks:
+
+    brew cask install mysides
+
+If you prefer not to use Homebrew, you can also download and run the prebuilt package in the [Releases tab]
+
 ## Usage ##
 
 List sidebar favorites items:
@@ -32,3 +40,4 @@ portions (l) copyleft 2011 Adam Strzelecki nanoant.com
 without whom I would not know much about the LSSharedFileList API.
 
  [1013-regression]: https://openradar.appspot.com/radar?id=4985135170584576
+ [Releases tab]: https://github.com/mosen/mysides/releases


### PR DESCRIPTION
Fixes #19, Added basic README docs describing how to install 

I went ahead and [built/submitted a Homebrew Cask](https://github.com/Homebrew/homebrew-cask/pull/61139) to make installation of mysides easily programatic (which fits with the purpose of the tool in the first place). So the argument could be made that this PR shouldn't be merged until the Homebrew PR is approved/merged. 